### PR TITLE
fix: remediate pyasn1 security finding

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1329,14 +1329,14 @@ files = [
 
 [[package]]
 name = "pyasn1"
-version = "0.6.1"
+version = "0.6.2"
 description = "Pure-Python implementation of ASN.1 types and DER/BER/CER codecs (X.208)"
 optional = false
 python-versions = ">=3.8"
 groups = ["main"]
 files = [
-    {file = "pyasn1-0.6.1-py3-none-any.whl", hash = "sha256:0d632f46f2ba09143da3a8afe9e33fb6f92fa2320ab7e886e2d0f7672af84629"},
-    {file = "pyasn1-0.6.1.tar.gz", hash = "sha256:6f580d2bdd84365380830acf45550f2511469f673cb4a5ae3857a3170128b034"},
+    {file = "pyasn1-0.6.2-py3-none-any.whl", hash = "sha256:1eb26d860996a18e9b6ed05e7aae0e9fc21619fcee6af91cca9bad4fbea224bf"},
+    {file = "pyasn1-0.6.2.tar.gz", hash = "sha256:9b59a2b25ba7e4f8197db7686c09fb33e658b98339fadb826e9512629017833b"},
 ]
 
 [[package]]


### PR DESCRIPTION
# Security Remediation Run

- status: `failed`
- repo: `Von-Base-Enterprises/core-nexus`
- branch: `security/core-nexus-cve-2026-23490`
- PR: n/a
- run_dir: `/home/vonbase/hermes-agent/workspace/security_remediation/runs/20260707T182228Z-run`

## Selected Fix

- id: `CVE-2026-23490`
- package: `pyasn1`
- severity: `high`
- source: `trivy`
- title: pyasn1: pyasn1: Denial of Service due to memory exhaustion from malformed RELATIVE-OID

## Findings

- before: 92
- after: 90

## Gates

- `scanner`: pass - selected_removed=True; before=92 after=90 new_high_or_critical=[] known_before=True
- `install`: pass
- `build_or_test_when_available`: pass
- `git_diff_review`: pass - changed_files=['poetry.lock']; risky=[]; unrelated=[]

## Human Action Required

- none

## Logs

- verification: `/home/vonbase/hermes-agent/workspace/security_remediation/runs/20260707T182228Z-run/verification.log`
- scanner_results: `/home/vonbase/hermes-agent/workspace/security_remediation/runs/20260707T182228Z-run/scanner-results`
- codex_transcript: `/home/vonbase/hermes-agent/workspace/security_remediation/runs/20260707T182228Z-run/codex-transcript.md`
