### PR TITLE
fix: remediate urllib3 security finding

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1894,21 +1894,21 @@ files = [
 
 [[package]]
 name = "urllib3"
-version = "2.4.0"
+version = "2.7.0"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 groups = ["main", "docs"]
 files = [
-    {file = "urllib3-2.4.0-py3-none-any.whl", hash = "sha256:4e16665048960a0900c702d4a66415956a584919c03361cac9f1df5c5dd7e813"},
-    {file = "urllib3-2.4.0.tar.gz", hash = "sha256:414bc6535b787febd7567804cc015fee39daab8ad86268f1310a9250697de466"},
+    {file = "urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897"},
+    {file = "urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c"},
 ]
 
 [package.extras]
-brotli = ["brotli (>=1.0.9) ; platform_python_implementation == \"CPython\"", "brotlicffi (>=0.8.0) ; platform_python_implementation != \"CPython\""]
+brotli = ["brotli (>=1.2.0) ; platform_python_implementation == \"CPython\"", "brotlicffi (>=1.2.0.0) ; platform_python_implementation != \"CPython\""]
 h2 = ["h2 (>=4,<5)"]
 socks = ["pysocks (>=1.5.6,!=1.5.7,<2.0)"]
-zstd = ["zstandard (>=0.18.0)"]
+zstd = ["backports-zstd (>=1.0.0) ; python_version < \"3.14\""]
 
 [[package]]
 name = "virtualenv"


### PR DESCRIPTION
# Security Remediation Run

- status: `failed`
- repo: `Von-Base-Enterprises/core-nexus`
- branch: `security/core-nexus-cve-2025-66418`
- PR: n/a
- run_dir: `/home/vonbase/hermes-agent/workspace/security_remediation/runs/20260707T204728Z-run`

## Selected Fix

- id: `CVE-2025-66418`
- package: `urllib3`
- severity: `high`
- source: `trivy`
- title: urllib3: urllib3: Unbounded decompression chain leads to resource exhaustion

## Findings

- before: 92
- after: 84

## Gates

- `scanner`: pass - selected_removed=True; before=92 after=84 new_high_or_critical=[] known_before=True
- `install`: pass
- `build_or_test_when_available`: pass
- `git_diff_review`: pass - changed_files=['poetry.lock']; risky=[]; unrelated=[]

## Human Action Required

- none

## Logs

- verification: `/home/vonbase/hermes-agent/workspace/security_remediation/runs/20260707T204728Z-run/verification.log`
- scanner_results: `/home/vonbase/hermes-agent/workspace/security_remediation/runs/20260707T204728Z-run/scanner-results`
- codex_transcript: `/home/vonbase/hermes-agent/workspace/security_remediation/runs/20260707T204728Z-run/codex-transcript.md`
