### PR TITLE
fix: remediate httplib2 security finding

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -747,18 +747,18 @@ protobuf = ">=5.26.1,<6.0dev"
 
 [[package]]
 name = "httplib2"
-version = "0.22.0"
+version = "0.32.0"
 description = "A comprehensive HTTP client library."
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+python-versions = ">=3.8"
 groups = ["main"]
 files = [
-    {file = "httplib2-0.22.0-py3-none-any.whl", hash = "sha256:14ae0a53c1ba8f3d37e9e27cf37eabb0fb9980f435ba405d546948b009dd64dc"},
-    {file = "httplib2-0.22.0.tar.gz", hash = "sha256:d7a10bc5ef5ab08322488bde8c726eeee5c8618723fdb399597ec58f3d82df81"},
+    {file = "httplib2-0.32.0-py3-none-any.whl", hash = "sha256:dc6705cacdf3fb0a2aba7629fa33c90fd93e30035db0c157325826be177e4816"},
+    {file = "httplib2-0.32.0.tar.gz", hash = "sha256:48a0ef30a42db65d8f3399045e1d09ab0ba66e3b9efc360d07f80ea55d286025"},
 ]
 
 [package.dependencies]
-pyparsing = {version = ">=2.4.2,<3.0.0 || >3.0.0,<3.0.1 || >3.0.1,<3.0.2 || >3.0.2,<3.0.3 || >3.0.3,<4", markers = "python_version > \"3.0\""}
+pyparsing = ">=3.1,<4"
 
 [[package]]
 name = "identify"


### PR DESCRIPTION
# Security Remediation Run

- status: `failed`
- repo: `Von-Base-Enterprises/core-nexus`
- branch: `security/core-nexus-cve-2026-59939-20260724t195946z-run`
- PR: n/a
- run_dir: `/home/vonbase/hermes-agent/workspace/security_remediation/runs/20260724T195946Z-run`

## Selected Fix

- id: `CVE-2026-59939`
- package: `httplib2`
- severity: `high`
- source: `trivy`
- title: httplib2: httplib2: Denial of Service via unbounded decompression of HTTP response bodies

## Findings

- before: 110
- after: 108

## Gates

- `scanner`: pass - selected_removed=True; before=110 after=108 new_high_or_critical=[] known_before=True
- `install`: pass
- `build_or_test_when_available`: pass
- `git_diff_review`: pass - changed_files=['poetry.lock']; risky=[]; unrelated=[]

## Human Action Required

- none

## Logs

- verification: `/home/vonbase/hermes-agent/workspace/security_remediation/runs/20260724T195946Z-run/verification.log`
- scanner_results: `/home/vonbase/hermes-agent/workspace/security_remediation/runs/20260724T195946Z-run/scanner-results`
- codex_transcript: `/home/vonbase/hermes-agent/workspace/security_remediation/runs/20260724T195946Z-run/codex-transcript.md`
